### PR TITLE
Moved dependencies from ssh to http

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "deps/dune"]
 	path = deps/dune
-	url = git@github.com:ix-project/dune.git
+	url = https://github.com:ix-project/dune.git
 [submodule "deps/pcidma"]
 	path = deps/pcidma
-	url = git@github.com:ix-project/pcidma.git
+	url = https://github.com:ix-project/pcidma.git
 [submodule "deps/dpdk"]
 	path = deps/dpdk
-	url = git://dpdk.org/dpdk
+	url = http://dpdk.org/git/dpdk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "deps/dune"]
 	path = deps/dune
-	url = https://github.com:ix-project/dune.git
+	url = https://github.com/ix-project/dune.git
 [submodule "deps/pcidma"]
 	path = deps/pcidma
-	url = https://github.com:ix-project/pcidma.git
+	url = https://github.com/ix-project/pcidma.git
 [submodule "deps/dpdk"]
 	path = deps/dpdk
 	url = http://dpdk.org/git/dpdk


### PR DESCRIPTION
Current git submodule dependencies are cloned through ssh.  While this form of git repository is valid, this suggested change is the result of 1) the additional dependency on the build environment (openssh for example) and 2) the fact that these repositories are public anyway and ssh authentication is not used to access their contents.